### PR TITLE
Main/ripple.sh: Remove invalid source directive for shellcheck

### DIFF
--- a/Main/ripple.sh
+++ b/Main/ripple.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shellcheck shell=sh # Written to be posix compatible
-# shellcheck source=/dev/null
 # shellcheck disable=SC2128,SC2178 # False Trigger
 # shellcheck disable=SC2039 # Non-Acute Trigger
 # USING: APT, Pacman, Portage, Paludis, UNIX or GNU/Linux, Mysql/Mariadb Database.


### PR DESCRIPTION
Why are you trying to source /dev/null through shellcheck? There is no 
shell syntax in that file other then garbage.. See 
https://github.com/koalaman/shellcheck/wiki/Directive#source for usage